### PR TITLE
Update to 1.14.1 & Bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ################################
 ### We use a java base image ###
 ################################
-FROM openjdk:12 AS build
+FROM openjdk:8 AS build
 
 #####################################
 ### Maintained by Felix Klauke    ###
@@ -25,10 +25,10 @@ ADD ${PAPERSPIGOT_CI_URL} /opt/minecraft/server/paperclip.jar
 ### Run paperclip and obtain patched jar ###
 ############################################
 RUN cd /opt/minecraft/server/ \
-    && java -jar paperclip.jar; exit 0
+	&& java -jar paperclip.jar; exit 0
 
 RUN cd /opt/minecraft/server/ \
-    && mv cache/patched*.jar paperspigot.jar
+	&& mv cache/patched*.jar paperspigot.jar
 
 ###########################
 ### Running environment ###
@@ -47,17 +47,18 @@ ENV JAVA_ARGS "-Xmx2G -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -server -Dcom.moj
 ENV SPIGOT_ARGS "--bukkit-settings ${CONFIG_PATH}/bukkit.yml --plugins ${PLUGINS_PATH} --world-dir ${WORLDS_PATH} --spigot-settings ${CONFIG_PATH}/spigot.yml --commands-settings ${CONFIG_PATH}/commands.yml --config ${CONFIG_PATH}/server.properties"
 ENV PAPERSPIGOT_ARGS "--paper-settings ${CONFIG_PATH}/paper.yml"
 
+############
+### User ###
+############
+RUN adduser -Ds /bin/bash -h /opt/minecraft papermc
+RUN mkdir -p /opt/minecraft/server
+RUN chown -R papermc /opt/minecraft
+USER papermc
+
 #########################
 ### Working directory ###
 #########################
 WORKDIR /opt/minecraft/server
-
-############
-### User ###
-############
-RUN useradd -ms /bin/bash minecraft
-RUN chown minecraft /opt/minecraft -R
-USER minecraft
 
 ###########################################
 ### Obtain runable jar from build stage ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ################################
 ### We use a java base image ###
 ################################
-FROM openjdk:8 AS build
+FROM openjdk:12 AS build
 
 #####################################
 ### Maintained by Felix Klauke    ###
@@ -12,8 +12,8 @@ MAINTAINER Felix Klauke <info@felix-klauke.de>
 #################
 ### Arguments ###
 #################
-ARG PAPERSPIGOT_CI_JOB=Paper
-ARG PAPERSPIGOT_CI_BUILDNUMBER=1613
+ARG PAPERSPIGOT_CI_JOB=Paper-1.14
+ARG PAPERSPIGOT_CI_BUILDNUMBER=lastSuccessfulBuild
 ARG PAPERSPIGOT_CI_URL=https://papermc.io/ci/job/${PAPERSPIGOT_CI_JOB}/${PAPERSPIGOT_CI_BUILDNUMBER}/artifact/paperclip.jar
 
 ##########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,9 @@ FROM anapsix/alpine-java:latest
 ARG MINECRAFT_PATH=/opt/minecraft
 ARG CONFIG_PATH=${MINECRAFT_PATH}/config
 ARG WORLDS_PATH=${MINECRAFT_PATH}/worlds
-ARG PLUGINS_PATH=${MINECRAFT_PATH}/plugins
 
 ENV JAVA_ARGS "-Xmx2G -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -server -Dcom.mojang.eula.agree=true"
-ENV SPIGOT_ARGS "--bukkit-settings ${CONFIG_PATH}/bukkit.yml --plugins ${PLUGINS_PATH} --world-dir ${WORLDS_PATH} --spigot-settings ${CONFIG_PATH}/spigot.yml --commands-settings ${CONFIG_PATH}/commands.yml --config ${CONFIG_PATH}/server.properties"
+ENV SPIGOT_ARGS "--bukkit-settings ${CONFIG_PATH}/bukkit.yml --world-dir ${WORLDS_PATH} --spigot-settings ${CONFIG_PATH}/spigot.yml --commands-settings ${CONFIG_PATH}/commands.yml --config ${CONFIG_PATH}/server.properties"
 ENV PAPERSPIGOT_ARGS "--paper-settings ${CONFIG_PATH}/paper.yml"
 
 ############
@@ -75,7 +74,7 @@ ADD start.sh .
 ###############
 VOLUME "/opt/minecraft/config"
 VOLUME "/opt/minecraft/worlds"
-VOLUME "/opt/minecraft/plugins"
+VOLUME "/opt/minecraft/server/plugins"
 
 #############################
 ### Expose minecraft port ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   minecraft:
-    image: t3rminus/paperspigot:1.14
+    image: felixklauke/paperspigot:1.12.2
     restart: always
     ports:
       - 25565:25565

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   minecraft:
-    image: felixklauke/paperspigot:1.12.2
+    image: t3rminus/paperspigot:1.14
     restart: always
     ports:
       - 25565:25565


### PR DESCRIPTION
This PR updates the build to 1.14

Also includes a couple of fixes for issues I encountered:
- some plugins don't work properly when the /plugins/ folder is not in the default location (CoreProtect)
- The "run as user" changes weren't working at all, and many directories (eg. world) were still being mounted as root