### PR TITLE
Use only minor version numbers to make managing the project easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,51 +20,45 @@ deploy:
 
 matrix:
   include:
-    - name: "Minecraft 1.8.8"
+    - name: "Minecraft 1.8"
       env:
-        - MINECRAFT_VERSION_TAG=1.8.8
+        - MINECRAFT_VERSION_TAG=1.8
         - PAPERSPIGOT_CI_JOB=Paper
         - PAPERSPIGOT_CI_BUILDNUMBER=443
         - ARTIFACT_NAME=Paperclip.jar
-    - name: "Minecraft 1.9.4"
+    - name: "Minecraft 1.9"
       env:
-        - MINECRAFT_VERSION_TAG=1.9.4
+        - MINECRAFT_VERSION_TAG=1.9
         - PAPERSPIGOT_CI_JOB=Paper
         - PAPERSPIGOT_CI_BUILDNUMBER=773
         - ARTIFACT_NAME=paperclip.jar
-    - name: "Minecraft 1.10.2"
+    - name: "Minecraft 1.10"
       env:
-        - MINECRAFT_VERSION_TAG=1.10.2
+        - MINECRAFT_VERSION_TAG=1.10
         - PAPERSPIGOT_CI_JOB=Paper
         - PAPERSPIGOT_CI_BUILDNUMBER=916
         - ARTIFACT_NAME=paperclip.jar
-    - name: "Minecraft 1.11.2"
+    - name: "Minecraft 1.11"
       env:
-        - MINECRAFT_VERSION_TAG=1.11.2
+        - MINECRAFT_VERSION_TAG=1.11
         - PAPERSPIGOT_CI_JOB=Paper
         - PAPERSPIGOT_CI_BUILDNUMBER=1104
         - ARTIFACT_NAME=paperclip.jar
-    - name: "Minecraft 1.12.2"
+    - name: "Minecraft 1.12"
       env:
-        - MINECRAFT_VERSION_TAG=1.10.2
+        - MINECRAFT_VERSION_TAG=1.12
         - PAPERSPIGOT_CI_JOB=Paper
         - PAPERSPIGOT_CI_BUILDNUMBER=1613
         - ARTIFACT_NAME=paperclip.jar
-    - name: "Minecraft 1.13.2"
+    - name: "Minecraft 1.13"
       env:
-        - MINECRAFT_VERSION_TAG=1.13.2
+        - MINECRAFT_VERSION_TAG=1.13
         - PAPERSPIGOT_CI_JOB=Paper-1.13
         - PAPERSPIGOT_CI_BUILDNUMBER=627
         - ARTIFACT_NAME=paperclip.jar
-    - name: "Minecraft 1.14.1"
+    - name: "Minecraft 1.14"
       env:
-        - MINECRAFT_VERSION_TAG=1.14.1
-        - PAPERSPIGOT_CI_JOB=Paper-1.14
-        - PAPERSPIGOT_CI_BUILDNUMBER=50
-        - ARTIFACT_NAME=paperclip.jar
-    - name: "Minecraft 1.14.2"
-      env:
-        - MINECRAFT_VERSION_TAG=1.14.2
+        - MINECRAFT_VERSION_TAG=1.14
         - PAPERSPIGOT_CI_JOB=Paper-1.14
         - PAPERSPIGOT_CI_BUILDNUMBER=lastSuccessfulBuild
         - ARTIFACT_NAME=paperclip.jar


### PR DESCRIPTION
Also: Your 1.12.2 build had MINECRAFT_VERSION_TAG=1.10.2 in it