### PR TITLE
Add start_period in compose files to avoid failing health checks at start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN pip install mcstatus
 ###################
 ### Healthcheck ###
 ###################
-HEALTHCHECK --interval=10s --timeout=5s \
+HEALTHCHECK --interval=10s --timeout=5s --start-period=120s \
     CMD mcstatus localhost:$( cat $PROPERTIES_LOCATION | grep "server-port" | cut -d'=' -f2 ) ping
 
 #########################

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ services:
     stdin_open: true
     tty: true
     restart: always
-    healthcheck:
-      start_period: 60s
     networks:
       - minecraft
     ports:
@@ -91,8 +89,6 @@ services:
     stdin_open: true
     tty: true
     restart: always
-    healthcheck:
-      start_period: 60s
     networks:
       - minecraft
     ports:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ services:
     stdin_open: true
     tty: true
     restart: always
+    healthcheck:
+      start_period: 60s
     networks:
       - minecraft
     ports:
@@ -89,6 +91,8 @@ services:
     stdin_open: true
     tty: true
     restart: always
+    healthcheck:
+      start_period: 60s
     networks:
       - minecraft
     ports:


### PR DESCRIPTION
Disregard failing health checks during start period (of 60 sec). Prevents container from being marked as 'unhealthy' and then restarted when deployed via docker swarm.