### PR TITLE
Fix: Server not shutting down gracefully; minor updates and changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ LABEL maintainer="Felix Klauke <info@felix-klauke.de>"
 #################
 ### Arguments ###
 #################
-ARG PAPER_VERSION=1.14.4
+ARG PAPER_VERSION=1.16.1
 ARG PAPER_DOWNLOAD_URL=https://papermc.io/api/v1/paper/${PAPER_VERSION}/latest/download
 ARG MINECRAFT_BUILD_USER=minecraft-build
 ENV MINECRAFT_BUILD_PATH=/opt/minecraft

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # paperspigot-docker
-Easy to use and clean docker image for running paper spigot servers in docker containers using OpenJDK. 
+Easy to use and clean Docker image for running Paper Spigot servers in Docker containers using OpenJDK. 
 
-You may also be interest in [waterfall-docker](https://github.com/FelixKlauke/waterfall-docker) if you want to build a whole server network.
+You may also be interested in [waterfall-docker](https://github.com/FelixKlauke/waterfall-docker) if you want to build a whole server network.
 
 # Getting started
 The easiest way for a quick start would be:
@@ -17,7 +17,7 @@ docker run -it \
 ```
 
 # Tags and Versions
-The docker images are tagged for their minecraft versions. Therefor you can currently choose between this versions:
+The Docker images are tagged for their Minecraft versions. These versions are currently available:
 - `felixklauke/paperspigot:1.16.1` 
 - `felixklauke/paperspigot:1.15.2` 
 - `felixklauke/paperspigot:1.15.1` 
@@ -38,21 +38,24 @@ The docker images are tagged for their minecraft versions. Therefor you can curr
 - `felixklauke/paperspigot:1.9.4`
 - `felixklauke/paperspigot:1.8.8`
 
-The specific images are update by hand. The 1.x-latest images will update at nightly builds and will always
+The specific images are updated by hand. The 1.x-latest images will update at nightly builds and will always
 use the latest build.
 
 # Volumes
-There are five volumes used for:
+There are five volumes which are used for:
 - Worlds
 - Plugins
 - Config files (paper.yml, bukkit.yml, spigot.yml, server.properties, commands.yml)
 - Data (banned-ips.json, banned-players.json, help.yml, ops.json, permissions.yml, whitelist.json)
 - Logs
 
-You can find the mount locations in the `docker-compose.yml`
+You can find the mount locations in `docker-compose.yml`.
 
 # docker-compose.yml
-You can add this simple entry to your docker-compose.yml when using mounted folders:
+## Bind Mounts
+This method is recommended if you have an already existing server which you wish to run inside a container [due to
+the way bind mounts behave.](https://docs.docker.com/storage/bind-mounts/#mount-into-a-non-empty-directory-on-the-container)
+You can add this simple entry to your docker-compose.yml when using bind mounts:
 ```yaml
 version: '3.7'
 
@@ -79,7 +82,8 @@ networks:
 
 ```
 
-When you want to use explicit volumes, you can use this:
+## Volumes
+If you want to use explicit volumes, you can use this:
 ```yaml 
 version: '3.7'
 
@@ -112,3 +116,9 @@ networks:
   minecraft: {}
 
 ```
+
+# See Also
+- [Docker CLI Reference: docker cp](https://docs.docker.com/engine/reference/commandline/cp/) - Copy files/folders between 
+a container and the local filesystem. Useful if you want to add new plugins, change settings, etc.
+- [Docker CLI Reference: docker attach](https://docs.docker.com/engine/reference/commandline/attach/) - Attach to a
+running container. Will attach to the server's console directly, allowing you to issue commands. 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [[ "$1" = 'serve' ]];  then
 
   # Start server
-  java -jar $JAVA_ARGS \
+  exec java -jar $JAVA_ARGS \
     -Xmx$JAVA_HEAP_SIZE -Xms$JAVA_HEAP_SIZE \
     $SERVER_PATH/paper.jar \
     $SPIGOT_ARGS \


### PR DESCRIPTION
While experimenting with the image I noticed that whenever I stopped my container with `docker container stop`, it would wait the full 10 seconds, then sending a `SIGKILL` signal and forcefully shutting down the server. This suggested that the Paperspigot server wasn't being shutdown gracefully, which may lead to data being lost, such as chunks not getting saved or getting corrupted, or user data being lost.

To fix this issue, only a minor change in the `docker-entrypoint.sh` script was necessary: Starting Java via the [exec](https://man7.org/linux/man-pages/man3/exec.3.html) command. This makes the child process spawned by the script "take over" the current process it is running in. When sending a `SIGTERM` signal to a container via `docker container stop`, the signal is **only sent to the process with PID 1,** because `/bin/bash` doesn't forward signals to any child processes [(source)](https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/). Because Java is now able to receive system signals, the server can correctly respond to `SIGTERM` and shutdown gracefully, as if the `/stop` command was issued.

Other minor updates and changes include updating `PAPER_VERSION` in the Dockerfile to the latest paper version, and fixing some minor grammar and spelling mistakes in `README.md`, as well as adding a "see also" section, which might be handy for server admins not fully used to Docker.