### PR TITLE
Use 2.7-compatible get-pip.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ENV PAPER_ARGS=""
 #################
 ### Libraries ###
 #################
-ADD https://bootstrap.pypa.io/get-pip.py .
+ADD https://bootstrap.pypa.io/2.7/get-pip.py .
 RUN python get-pip.py
 
 RUN pip install mcstatus

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ENV PAPER_ARGS=""
 #################
 ### Libraries ###
 #################
-ADD https://bootstrap.pypa.io/2.7/get-pip.py .
+ADD https://bootstrap.pypa.io/pip/2.7/get-pip.py .
 RUN python get-pip.py
 
 RUN pip install mcstatus


### PR DESCRIPTION
When updating my server, it errored out at line 74 (build step 28), as the original url now downloads a 3.6+ version of get-pip.py
This fix should be treated as temporary, as "pip 21.0 will drop support for Python 2.7 in January 2021." is warned by the script itself.
The correct fix may rely on the openjdk images switching to python3, or manually installing python3 in this script.